### PR TITLE
Consolidated testing code in test/support; removed elixir_ale dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: elixir:1.4.2
+      - image: elixir:1.4
 
     working_directory: ~/ex_lcd
 
@@ -14,4 +14,29 @@ jobs:
       - run: mix deps.compile
 
       # Run tests
-      - run: MIX_ENV=test mix test
+      - run:
+          environment:
+            MIX_ENV: "test"
+          command: |
+            mix test
+
+  deploy_hex:
+    docker:
+      - image: elixir:1.4
+
+    working_directory: ~/ex_lcd_deploy
+
+    steps:
+      - checkout
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+      - run: mix deps.get
+      - run: mix deps.compile
+      # - run: mix hex.auth something something??
+
+      # Deploy to Hex
+      - deploy:
+        command: |
+          if [ ${CIRCLE_BRANCH} == "master" ]; then
+            # publish the package release here...
+          fi

--- a/README.md
+++ b/README.md
@@ -4,50 +4,44 @@
 [![Hex.pm](https://img.shields.io/hexpm/dt/ex_lcd.svg)](https://hex.pm/packages/ex_lcd)
 [![Hex.pm](https://img.shields.io/hexpm/l/ex_lcd.svg)](https://hex.pm/packages/ex_lcd)
 
-**ExLCD** is a Hex package providing an API and support for character
-matrix LCD displays in your Elixir and nerves projects. It uses
-[elixir_ale](https://github.com/fhunleth/elixir_ale) for hardware IO.
+**ExLCD** is a Hex package providing an API and support for character matrix LCD displays in your Elixir and nerves projects. It uses [elixir_ale](https://github.com/fhunleth/elixir_ale) for hardware IO.
 
-The hardware interface and the user API are separate modules providing
-relative hardware independence. This provides you with the ability
-to change displays without significant changes your application code.
+The hardware interface and the user API are separate modules providing relative hardware independence. This provides you with the ability to change displays without significant changes your application code.
 
-**Disclaimer** This is still under heavy development and probably isn't suited
-for production use. Please consider testing and contributing to improving the
-project.
+**Disclaimer:** This is still under heavy development and probably isn't suited for production use. Please consider testing and contributing to improving the project.
+
+## Documentation
+
+Project and API documentation is available online at [hexdocs.pm](https://hexdocs.pm/ex_lcd/)
 
 ## Examples
 
-Example projects using ExLCD are available in the
-[ex_lcd_examples](https://github.com/cthree/ex_lcd_examples)
-Github repository.
+Example applications using ExLCD are available in the [cthree/ex_lcd_examples](https://github.com/cthree/ex_lcd_examples) Github repository.
 
 ## Contributing
 
-If you wish to develop a new driver to support an unsupported display
-module, fix or report a bug, add a feature or otherwise contribute to
-the project please open an issue to discuss your issue or idea. I'm
-happy to accept suggestions, bug reports, pull requests and other
-help! Driver modules for unsupported displays is especially appreciated.
+If you wish to support a new type of display module, fix or report a bug, add a feature or otherwise contribute to the project please [open an issue](https://github.com/cthree/ex_lcd/issues) to discuss your issue or idea. I'm happy to accept suggestions, bug reports, pull requests and other help. Driver modules for unsupported displays is especially appreciated.
 
 ## Acknowledgements
 
-Many thanks to [@tmecklem](https://github.com/tmecklem) for inspiration
-and encouragement. ExLCD started as his elixir_lcd package. While none of
-the original code remains, his guidance and advice is greatly appreciated.
+Many thanks to [@tmecklem](https://github.com/tmecklem) for inspiration and encouragement. ExLCD started as his **elixir_lcd** package. While none of the original code remains, his guidance and advice is greatly appreciated.
+
+## License
+
+Licensed under the [Apache-2.0](https://choosealicense.com/licenses/apache-2.0/) license. Please see the [LICENSE file](https://github.com/cthree/ex_lcd/blob/master/LICENSE.txt) included in the repository if you are unfamiliar with the terms and conditions.
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+**ExLCD** [is available in Hex](https://hex.pm/docs/publish), the package can be installed as a dependency of your project:
 
-  1. Add ex_lcd to your list of dependencies in `mix.exs`:
+  1. Add **ex_lcd** and **elixir_ale** to your list of dependencies in `mix.exs`:
+          def deps do
+            [{:elixir_ale, "~> 0.6"},
+             {:ex_lcd, "~> 0.3.2"}]
+          end
 
-        def deps do
-          [{:ex_lcd, "~> 0.3.0"}]
-        end
-
-  2. Ensure ex_lcd is started before your application:
-
-        def application do
-          [applications: [:ex_lcd]]
-        end
+  2. Ensure **ex_lcd** is started before your application:
+          def application(_target) do
+            [mod: {MyApplication.Application, []},
+             extra_applications: [:ex_lcd]]
+          end

--- a/lib/ex_lcd/hd44780.ex
+++ b/lib/ex_lcd/hd44780.ex
@@ -419,37 +419,8 @@ defmodule ExLCD.HD44780 do
     |>  en(@low)
   end
 
-  defp delay(display, ms) do
-    Process.sleep(ms)
-    display
-  end
-
-end
-
-# For testing ExLCD and building for the host (no hardware)
-# we stub out elixir_ale.
-if ExLCD.Driver.target == "host" do
-  # Not testing, stub out the hardware mock because it's part of
-  # the test system
-  if Mix.env != :test do
-    defmodule MockHD44780 do
-      @moduledoc false
-      def write(_, _), do: :ok
-    end
-  end
-
-  defmodule ElixirALE.GPIO do
-    @moduledoc false
-
-    def start_link(pin, _pin_direction \\ :foo, _opts \\ []) do
-      {:ok, pin}
-    end
-
-    def write(pin, value) do
-      MockHD44780.write(pin, value)
-      :ok
-    end
-
-    def release(_pin), do: :ok
-  end
+  # defp delay(display, ms) do
+  #   Process.sleep(ms)
+  #   display
+  # end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExLCD.Mixfile do
 
   def project do
     [app: :ex_lcd,
-     version: "0.3.1",
+     version: "0.3.2",
      elixir: "~> 1.4",
      description: description(),
      package: package(),
@@ -25,7 +25,7 @@ defmodule ExLCD.Mixfile do
 
   defp deps do
     [
-      {:elixir_ale, "~> 0.6.0", only: :prod},
+      # {:elixir_ale, "~> 0.6.0", only: :prod},
       {:ex_doc, "~> 0.11", only: [:dev]}
     ]
   end

--- a/test/support/mock_ale.ex
+++ b/test/support/mock_ale.ex
@@ -1,0 +1,17 @@
+#
+# Stub out elixir_ale for testing
+#
+defmodule ElixirALE.GPIO do
+  @moduledoc false
+
+  def start_link(pin, _pin_direction \\ :foo, _opts \\ []) do
+    {:ok, pin}
+  end
+
+  def write(pin, value) do
+    MockHD44780.write(pin, value)
+    :ok
+  end
+
+  def release(_pin), do: :ok
+end


### PR DESCRIPTION
All testing code was moved into test/support and the dependency for elixir_ale was dropped. Users of the library will now be required to include elixir_ale as a dependency of their own projects. The README was update to reflect the dependency change.

Trying to be smart about when to include the elixir_ale dependency was causing build and complicating the use of the ex_lcd library. I decided to push the elixir_ale issue upstream as ex_lcd is not the right place to deal with it.

The result is the library will have fewer conflicts and be easier to use. If the user forgets to include the elixir_ale dependency the compiler will tell them such when they build their image.